### PR TITLE
hcloud cluster maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add the deployment and service
 
 Add the cert-manager resources
 
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
 
 Add the cluster issuers
 
@@ -137,3 +137,13 @@ Update ingress
 Update the DNS entries with terraform
 
     terraform apply
+
+Create a backup of the postgres database
+
+    kubectl exec -it postgres-0 -- bash
+    pg_dump -U postgres <out.sql>
+
+Restore backup of the postgres database
+
+    kubectl exec -it postgres-0 -- bash
+    psql -U postgres -f <out.sql>

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add the deployment and service
 
 Add the cert-manager resources
 
-    kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
 
 Add the cluster issuers
 

--- a/bitwarden.yaml
+++ b/bitwarden.yaml
@@ -23,7 +23,7 @@ spec:
             claimName: vault
       containers:
         - name: bitwarden
-          image: vaultwarden/server:1.24.0-alpine
+          image: vaultwarden/server:1.26.0-alpine
           volumeMounts:
             - name: vault
               mountPath: /data

--- a/cvsite.yaml
+++ b/cvsite.yaml
@@ -15,17 +15,6 @@ spec:
       containers:
         - name: cvsite
           image: mhemeryck/cvsite:latest
-        - name: cvsite-prometheus-exporter
-          image: nginx/nginx-prometheus-exporter:0.8.0
-          env:
-            - name: SCRAPE_URI
-              value: http://localhost/metrics
-            - name: TELEMETRY_PATH
-              value: /metrics
-            - name: NGINX_RETRIES
-              value: "10"
-          ports:
-            - containerPort: 9113
 ---
 apiVersion: v1
 kind: Service
@@ -39,22 +28,3 @@ spec:
   ports:
     - name: web
       port: 80
-    - name: metrics
-      port: 9113
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: cvsite-monitor
-  labels:
-    app: cvsite
-    release: prometheus
-spec:
-  selector:
-    matchLabels:
-      app: cvsite
-  namespaceSelector:
-    any: true
-  endpoints:
-    - port: metrics
-      interval: 15s

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik-ingress
   annotations:
     kubernetes.io/ingress.class: traefik
-    cert-manager.io/issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt
     ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   tls:

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: traefik-ingress
+  name: web
   annotations:
     kubernetes.io/ingress.class: traefik
     cert-manager.io/cluster-issuer: letsencrypt

--- a/issuer-letsencrypt-staging.yaml
+++ b/issuer-letsencrypt-staging.yaml
@@ -1,21 +1,14 @@
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging
-  namespace: default
 spec:
   acme:
-    # The ACME server URL
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    # Email address used for ACME registration
     email: martijn.hemeryck@gmail.com
-    # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-staging
-    # Enable the HTTP-01 challenge provider
     solvers:
-      # An empty 'selector' means that this solver matches all domains
-      - selector: {}
-        http01:
+      - http01:
           ingress:
             class: traefik

--- a/issuer-letsencrypt.yaml
+++ b/issuer-letsencrypt.yaml
@@ -1,21 +1,14 @@
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
 metadata:
   name: letsencrypt
-  namespace: default
 spec:
   acme:
-    # The ACME server URL
     server: https://acme-v02.api.letsencrypt.org/directory
-    # Email address used for ACME registration
     email: martijn.hemeryck@gmail.com
-    # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt
-    # Enable the HTTP-01 challenge provider
     solvers:
-      # An empty 'selector' means that this solver matches all domains
-      - selector: {}
-        http01:
+      - http01:
           ingress:
             class: traefik

--- a/mongo.yaml
+++ b/mongo.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: mongo
-          image: mongo:4.2.8-bionic
+          image: mongo:4.2.23-bionic
           volumeMounts:
             - name: mongodb-storage
               mountPath: /data/db

--- a/postgres.yaml
+++ b/postgres.yaml
@@ -1,14 +1,14 @@
 ---
 apiVersion: v1
-kind: Service
+kind: PersistentVolumeClaim
 metadata:
-  name: postgres
+  name: postgres-pgdata
 spec:
-  selector:
-    app: postgres
-  ports:
-    - port: 5432
-      targetPort: 5432
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -48,12 +48,12 @@ spec:
                   key: password
 ---
 apiVersion: v1
-kind: PersistentVolumeClaim
+kind: Service
 metadata:
-  name: postgres-pgdata
+  name: postgres
 spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/postgres.yaml
+++ b/postgres.yaml
@@ -31,7 +31,7 @@ spec:
             claimName: postgres-pgdata
       containers:
         - name: postgres
-          image: postgres:14.2-alpine3.15
+          image: postgres:15.0-alpine3.16
           resources:
             limits:
               memory: 512Mi

--- a/wekan.yaml
+++ b/wekan.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: wekan
-          image: wekanteam/wekan:v6.18
+          image: wekanteam/wekan:v6.53
           env:
             - name: MONGO_URL
               value: mongodb://mongodb/wekan


### PR DESCRIPTION
Certificates on the cluster weren't updated properly anymore.
This was due an incompatibility between a k3s update and the outdated version of cert-manager.
Later on, I did notice traefik (ingress) was also still on an older version.
In the end, the full cluster got scrapped and updated.

The hetzner image itself was recycled on order to keep using the older price point.
The VM is using fedora 36 -- since centos is no longer receiving updates.

All docker images are also updated to a recent version.

- Update cert-manager
- Move postgres definitions around
- Simplified manifests after cluster upgrade
- Updates
