### PR TITLE
remove managing mhemeryck.com from hetzner

### DIFF
--- a/node/dns.tf
+++ b/node/dns.tf
@@ -34,16 +34,3 @@ resource "hetznerdns_record" "blog" {
   type    = "CNAME"
   ttl     = 3600
 }
-
-resource "hetznerdns_zone" "com" {
-  name = "mhemeryck.com"
-  ttl  = 3600
-}
-
-resource "hetznerdns_record" "com" {
-  zone_id = hetznerdns_zone.com.id
-  name    = "@"
-  value   = hcloud_server.k3s.ipv4_address
-  type    = "A"
-  ttl     = 3600
-}


### PR DESCRIPTION
since the home network uses mhemeryck.com and hetzner is not supported as a DNS resolvers, I need to move this back to digitalocean