### PR TITLE
Update vaultwarden 1.31 -> 1.33

### DIFF
--- a/bitwarden.yaml
+++ b/bitwarden.yaml
@@ -29,7 +29,7 @@ spec:
             claimName: vault
       containers:
         - name: bitwarden
-          image: vaultwarden/server:1.31.0-alpine
+          image: vaultwarden/server:1.33.0-alpine
           volumeMounts:
             - name: vault
               mountPath: /data


### PR DESCRIPTION
App was no longer compatible, so definitely needed a newer version.

See e.g. https://www.reddit.com/r/vaultwarden/comments/1gv09ta/bitwarden_ios_app_not_working_with_selfhosted/